### PR TITLE
Software Compensation as Default

### DIFF
--- a/scripts/MarlinPandora.xml
+++ b/scripts/MarlinPandora.xml
@@ -54,14 +54,14 @@
   <parameter name="HCalToMipCalibration" type="float">38.0228</parameter>
   <parameter name="ECalMipThreshold" type="float">0.5</parameter>
   <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-  <parameter name="ECalToEMGeVCalibration" type="float">1.00356141304</parameter>
-  <parameter name="HCalToEMGeVCalibration" type="float">1.12083052744</parameter>
-  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.14127910463</parameter>
-  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.14127910463</parameter>
-  <parameter name="HCalToHadGeVCalibration" type="float">1.12083052744</parameter>
+  <parameter name="ECalToEMGeVCalibration" type="float">1.00326122634</parameter>
+  <parameter name="HCalToEMGeVCalibration" type="float">1.06166688118</parameter>
+  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.16376244596</parameter>
+  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.16376244596</parameter>
+  <parameter name="HCalToHadGeVCalibration" type="float">1.06166688118</parameter>
   <parameter name="MuonToMipCalibration" type="float">10.3093</parameter>
   <parameter name="DigitalMuonHits" type="int">0</parameter>
-  <parameter name="MaxHCalHitHadronicEnergy" type="float">1.0</parameter>
+  <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.0</parameter>
   <parameter name="AbsorberRadLengthECal" type="float">0.2854</parameter>
   <parameter name="AbsorberIntLengthECal" type="float">0.0101</parameter>
   <parameter name="AbsorberRadLengthHCal" type="float">0.0569</parameter>

--- a/scripts/MarlinPandoraValidation.xml
+++ b/scripts/MarlinPandoraValidation.xml
@@ -200,14 +200,14 @@
   <parameter name="HCalToMipCalibration" type="float">38.0228</parameter>
   <parameter name="ECalMipThreshold" type="float">0.5</parameter>
   <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-  <parameter name="ECalToEMGeVCalibration" type="float">1.00356141304</parameter>
-  <parameter name="HCalToEMGeVCalibration" type="float">1.12083052744</parameter>
-  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.14127910463</parameter>
-  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.14127910463</parameter>
-  <parameter name="HCalToHadGeVCalibration" type="float">1.12083052744</parameter>
+  <parameter name="ECalToEMGeVCalibration" type="float">1.00326122634</parameter>
+  <parameter name="HCalToEMGeVCalibration" type="float">1.06166688118</parameter>
+  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.16376244596</parameter>
+  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.16376244596</parameter>
+  <parameter name="HCalToHadGeVCalibration" type="float">1.06166688118</parameter>
   <parameter name="MuonToMipCalibration" type="float">10.3093</parameter>
   <parameter name="DigitalMuonHits" type="int">0</parameter>
-  <parameter name="MaxHCalHitHadronicEnergy" type="float">1.0</parameter>
+  <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.0</parameter>
   <parameter name="AbsorberRadLengthECal" type="float">0.2854</parameter>
   <parameter name="AbsorberIntLengthECal" type="float">0.0101</parameter>
   <parameter name="AbsorberRadLengthHCal" type="float">0.0569</parameter>
@@ -254,14 +254,14 @@
   <parameter name="HCalToMipCalibration" type="float">38.0228</parameter>
   <parameter name="ECalMipThreshold" type="float">0.5</parameter>
   <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-  <parameter name="ECalToEMGeVCalibration" type="float">1.00356141304</parameter>
-  <parameter name="HCalToEMGeVCalibration" type="float">1.12083052744</parameter>
-  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.14127910463</parameter>
-  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.14127910463</parameter>
-  <parameter name="HCalToHadGeVCalibration" type="float">1.12083052744</parameter>
+  <parameter name="ECalToEMGeVCalibration" type="float">1.00326122634</parameter>
+  <parameter name="HCalToEMGeVCalibration" type="float">1.06166688118</parameter>
+  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.16376244596</parameter>
+  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.16376244596</parameter>
+  <parameter name="HCalToHadGeVCalibration" type="float">1.06166688118</parameter>
   <parameter name="MuonToMipCalibration" type="float">10.3093</parameter>
   <parameter name="DigitalMuonHits" type="int">0</parameter>
-  <parameter name="MaxHCalHitHadronicEnergy" type="float">1.0</parameter>
+  <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.0</parameter>
   <parameter name="AbsorberRadLengthECal" type="float">0.2854</parameter>
   <parameter name="AbsorberIntLengthECal" type="float">0.0101</parameter>
   <parameter name="AbsorberRadLengthHCal" type="float">0.0569</parameter>
@@ -308,14 +308,14 @@
   <parameter name="HCalToMipCalibration" type="float">38.0228</parameter>
   <parameter name="ECalMipThreshold" type="float">0.5</parameter>
   <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-  <parameter name="ECalToEMGeVCalibration" type="float">1.00356141304</parameter>
-  <parameter name="HCalToEMGeVCalibration" type="float">1.12083052744</parameter>
-  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.14127910463</parameter>
-  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.14127910463</parameter>
-  <parameter name="HCalToHadGeVCalibration" type="float">1.12083052744</parameter>
+  <parameter name="ECalToEMGeVCalibration" type="float">1.00326122634</parameter>
+  <parameter name="HCalToEMGeVCalibration" type="float">1.06166688118</parameter>
+  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.16376244596</parameter>
+  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.16376244596</parameter>
+  <parameter name="HCalToHadGeVCalibration" type="float">1.06166688118</parameter>
   <parameter name="MuonToMipCalibration" type="float">10.3093</parameter>
   <parameter name="DigitalMuonHits" type="int">0</parameter>
-  <parameter name="MaxHCalHitHadronicEnergy" type="float">1.0</parameter>
+  <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.0</parameter>
   <parameter name="AbsorberRadLengthECal" type="float">0.2854</parameter>
   <parameter name="AbsorberIntLengthECal" type="float">0.0101</parameter>
   <parameter name="AbsorberRadLengthHCal" type="float">0.0569</parameter>
@@ -362,14 +362,14 @@
   <parameter name="HCalToMipCalibration" type="float">38.0228</parameter>
   <parameter name="ECalMipThreshold" type="float">0.5</parameter>
   <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-  <parameter name="ECalToEMGeVCalibration" type="float">1.00356141304</parameter>
-  <parameter name="HCalToEMGeVCalibration" type="float">1.12083052744</parameter>
-  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.14127910463</parameter>
-  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.14127910463</parameter>
-  <parameter name="HCalToHadGeVCalibration" type="float">1.12083052744</parameter>
+  <parameter name="ECalToEMGeVCalibration" type="float">1.00326122634</parameter>
+  <parameter name="HCalToEMGeVCalibration" type="float">1.06166688118</parameter>
+  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.16376244596</parameter>
+  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.16376244596</parameter>
+  <parameter name="HCalToHadGeVCalibration" type="float">1.06166688118</parameter>
   <parameter name="MuonToMipCalibration" type="float">10.3093</parameter>
   <parameter name="DigitalMuonHits" type="int">0</parameter>
-  <parameter name="MaxHCalHitHadronicEnergy" type="float">1.0</parameter>
+  <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.0</parameter>
   <parameter name="AbsorberRadLengthECal" type="float">0.2854</parameter>
   <parameter name="AbsorberIntLengthECal" type="float">0.0101</parameter>
   <parameter name="AbsorberRadLengthHCal" type="float">0.0569</parameter>
@@ -416,14 +416,14 @@
   <parameter name="HCalToMipCalibration" type="float">38.0228</parameter>
   <parameter name="ECalMipThreshold" type="float">0.5</parameter>
   <parameter name="HCalMipThreshold" type="float">0.3</parameter>
-  <parameter name="ECalToEMGeVCalibration" type="float">1.00356141304</parameter>
-  <parameter name="HCalToEMGeVCalibration" type="float">1.12083052744</parameter>
-  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.14127910463</parameter>
-  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.14127910463</parameter>
-  <parameter name="HCalToHadGeVCalibration" type="float">1.12083052744</parameter>
+  <parameter name="ECalToEMGeVCalibration" type="float">1.00326122634</parameter>
+  <parameter name="HCalToEMGeVCalibration" type="float">1.06166688118</parameter>
+  <parameter name="ECalToHadGeVCalibrationBarrel" type="float">1.16376244596</parameter>
+  <parameter name="ECalToHadGeVCalibrationEndCap" type="float">1.16376244596</parameter>
+  <parameter name="HCalToHadGeVCalibration" type="float">1.06166688118</parameter>
   <parameter name="MuonToMipCalibration" type="float">10.3093</parameter>
   <parameter name="DigitalMuonHits" type="int">0</parameter>
-  <parameter name="MaxHCalHitHadronicEnergy" type="float">1.0</parameter>
+  <parameter name="MaxHCalHitHadronicEnergy" type="float">1000000.0</parameter>
   <parameter name="AbsorberRadLengthECal" type="float">0.2854</parameter>
   <parameter name="AbsorberIntLengthECal" type="float">0.0101</parameter>
   <parameter name="AbsorberRadLengthHCal" type="float">0.0569</parameter>

--- a/scripts/PandoraSettingsBasic.xml
+++ b/scripts/PandoraSettingsBasic.xml
@@ -7,7 +7,7 @@
     <ShouldCollapseMCParticlesToPfoTarget>true</ShouldCollapseMCParticlesToPfoTarget>
 
     <!-- PLUGIN SETTINGS -->
-    <HadronicEnergyCorrectionPlugins>CleanClusters ScaleHotHadrons</HadronicEnergyCorrectionPlugins>
+    <HadronicEnergyCorrectionPlugins>SoftwareCompensation</HadronicEnergyCorrectionPlugins>
     <EmShowerPlugin>LCEmShowerId</EmShowerPlugin>
     <PhotonPlugin>LCPhotonId</PhotonPlugin>
     <ElectronPlugin>LCElectronId</ElectronPlugin>

--- a/scripts/PandoraSettingsDefault.xml
+++ b/scripts/PandoraSettingsDefault.xml
@@ -7,7 +7,7 @@
     <ShouldCollapseMCParticlesToPfoTarget>true</ShouldCollapseMCParticlesToPfoTarget>
 
     <!-- PLUGIN SETTINGS -->
-    <HadronicEnergyCorrectionPlugins>CleanClusters ScaleHotHadrons</HadronicEnergyCorrectionPlugins>
+    <HadronicEnergyCorrectionPlugins>SoftwareCompensation</HadronicEnergyCorrectionPlugins>
     <EmShowerPlugin>LCEmShowerId</EmShowerPlugin>
     <PhotonPlugin>LCPhotonId</PhotonPlugin>
     <ElectronPlugin>LCElectronId</ElectronPlugin>

--- a/scripts/PandoraSettingsMuon.xml
+++ b/scripts/PandoraSettingsMuon.xml
@@ -7,7 +7,7 @@
     <ShouldCollapseMCParticlesToPfoTarget>true</ShouldCollapseMCParticlesToPfoTarget>
 
     <!-- PLUGIN SETTINGS -->
-    <HadronicEnergyCorrectionPlugins>CleanClusters ScaleHotHadrons</HadronicEnergyCorrectionPlugins>
+    <HadronicEnergyCorrectionPlugins>SoftwareCompensation</HadronicEnergyCorrectionPlugins>
     <EmShowerPlugin>LCEmShowerId</EmShowerPlugin>
     <PhotonPlugin>LCPhotonId</PhotonPlugin>
     <ElectronPlugin>LCElectronId</ElectronPlugin>

--- a/scripts/PandoraSettingsPerfectPFA.xml
+++ b/scripts/PandoraSettingsPerfectPFA.xml
@@ -7,7 +7,7 @@
     <ShouldCollapseMCParticlesToPfoTarget>true</ShouldCollapseMCParticlesToPfoTarget>
 
     <!-- PLUGIN SETTINGS -->
-    <HadronicEnergyCorrectionPlugins>CleanClusters ScaleHotHadrons</HadronicEnergyCorrectionPlugins>
+    <HadronicEnergyCorrectionPlugins>SoftwareCompensation</HadronicEnergyCorrectionPlugins>
     <EmShowerPlugin>LCEmShowerId</EmShowerPlugin>
     <PhotonPlugin>LCPhotonId</PhotonPlugin>
     <ElectronPlugin>LCElectronId</ElectronPlugin>

--- a/scripts/PandoraSettingsPerfectPhoton.xml
+++ b/scripts/PandoraSettingsPerfectPhoton.xml
@@ -7,7 +7,7 @@
     <ShouldCollapseMCParticlesToPfoTarget>true</ShouldCollapseMCParticlesToPfoTarget>
 
     <!-- PLUGIN SETTINGS -->
-    <HadronicEnergyCorrectionPlugins>CleanClusters ScaleHotHadrons</HadronicEnergyCorrectionPlugins>
+    <HadronicEnergyCorrectionPlugins>SoftwareCompensation</HadronicEnergyCorrectionPlugins>
     <EmShowerPlugin>LCEmShowerId</EmShowerPlugin>
     <PhotonPlugin>LCPhotonId</PhotonPlugin>
     <ElectronPlugin>LCElectronId</ElectronPlugin>

--- a/scripts/PandoraSettingsPhotonTraining.xml
+++ b/scripts/PandoraSettingsPhotonTraining.xml
@@ -7,7 +7,7 @@
     <ShouldCollapseMCParticlesToPfoTarget>true</ShouldCollapseMCParticlesToPfoTarget>
 
     <!-- PLUGIN SETTINGS -->
-    <HadronicEnergyCorrectionPlugins>CleanClusters ScaleHotHadrons</HadronicEnergyCorrectionPlugins>
+    <HadronicEnergyCorrectionPlugins>SoftwareCompensation</HadronicEnergyCorrectionPlugins>
     <EmShowerPlugin>LCEmShowerId</EmShowerPlugin>
     <PhotonPlugin>LCPhotonId</PhotonPlugin>
     <ElectronPlugin>LCElectronId</ElectronPlugin>

--- a/scripts/PandoraSettingsSoftwareCompensationTraining.xml
+++ b/scripts/PandoraSettingsSoftwareCompensationTraining.xml
@@ -7,7 +7,6 @@
     <ShouldCollapseMCParticlesToPfoTarget>true</ShouldCollapseMCParticlesToPfoTarget>
 
     <!-- PLUGIN SETTINGS -->
-    <HadronicEnergyCorrectionPlugins>SoftwareCompensation</HadronicEnergyCorrectionPlugins>
     <EmShowerPlugin>LCEmShowerId</EmShowerPlugin>
     <PhotonPlugin>LCPhotonId</PhotonPlugin>
     <ElectronPlugin>LCElectronId</ElectronPlugin>
@@ -59,16 +58,17 @@
     </algorithm>
 
     <!-- Standalone photon clustering -->
-    <algorithm type = "ClusteringParent">
-        <algorithm type = "PerfectClustering" description = "ClusterFormation">
-            <ParticleIdList>22 2112 -2112 130 -130</ParticleIdList>
-        </algorithm>
-        <algorithm type = "TopologicalAssociationParent" description = "ClusterAssociation">
-            <associationAlgorithms>
-            </associationAlgorithms>
+    <algorithm type = "PhotonReconstruction">
+        <algorithm type = "ConeClustering" description = "PhotonClusterFormation">
+            <ClusterSeedStrategy>0</ClusterSeedStrategy>
+            <ShouldUseTrackSeed>false</ShouldUseTrackSeed>
+            <ShouldUseOnlyECalHits>true</ShouldUseOnlyECalHits>
+            <ConeApproachMaxSeparation>250.</ConeApproachMaxSeparation>
         </algorithm>
         <ClusterListName>PhotonClusters</ClusterListName>
         <ReplaceCurrentClusterList>false</ReplaceCurrentClusterList>
+        <ShouldMakePdfHistograms>false</ShouldMakePdfHistograms>
+        <HistogramFile>PandoraLikelihoodData9EBin.xml</HistogramFile>
     </algorithm>
 
     <!-- Clustering parent algorithm runs a daughter clustering algorithm -->
@@ -92,6 +92,10 @@
                 </algorithm>
                 <algorithm type = "MipPhotonSeparation">
                     <algorithm type = "TrackClusterAssociation"/>
+                </algorithm>
+                <algorithm type = "HighEnergyPhotonRecovery">
+                    <algorithm type = "TrackClusterAssociation"/>
+                    <AdditionalClusterListNames>PhotonClusters</AdditionalClusterListNames>
                 </algorithm>
                 <algorithm type = "SoftClusterMerging">
                     <algorithm type = "TrackClusterAssociation"/>
@@ -419,6 +423,9 @@
         <MergedCandidateListName>PfoCreation</MergedCandidateListName>
     </algorithm>
 
+    <algorithm type = "PhotonSplitting"/>
+    <algorithm type = "PhotonFragmentMerging"/>
+
     <!-- Create particle flow objects -->
     <algorithm type = "ForceSplitTrackAssociations"/>
     <algorithm type = "PfoCreation">
@@ -435,4 +442,10 @@
     <algorithm type = "V0PfoCreation"/>
     <!--algorithm type = "DumpPfosMonitoring"/-->
     <!--algorithm type = "VisualMonitoring"/-->
+
+    <!-- Extract necessary calo hit information needed for training software compensation -->
+    <algorithm type = "TrainingSoftwareCompensation">
+        <MyRootFileName>TrainingSoftwareCompensation.root</MyRootFileName>
+        <SoftCompTrainingTreeName>SoftwareCompensationTrainingTree</SoftCompTrainingTreeName>
+    </algorithm>
 </pandora>


### PR DESCRIPTION
Updated scripts to use software compensation as default.  Updated calibration numbers in MarlinPandora.xml and MarlinPandoraValidation.xml examples to reflect removal of the MaxHCalHitHadronicEnergy in favour of software compensation.
